### PR TITLE
Addition of ASM hook into StringTranslate

### DIFF
--- a/src/main/java/net/darkhax/wawla/asm/WAWLAClassTransformer.java
+++ b/src/main/java/net/darkhax/wawla/asm/WAWLAClassTransformer.java
@@ -1,0 +1,71 @@
+package net.darkhax.wawla.asm;
+
+import net.minecraft.launchwrapper.IClassTransformer;
+
+import org.objectweb.asm.ClassReader;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.tree.AbstractInsnNode;
+import org.objectweb.asm.tree.ClassNode;
+import org.objectweb.asm.tree.InsnList;
+import org.objectweb.asm.tree.JumpInsnNode;
+import org.objectweb.asm.tree.LabelNode;
+import org.objectweb.asm.tree.LineNumberNode;
+import org.objectweb.asm.tree.MethodInsnNode;
+import org.objectweb.asm.tree.MethodNode;
+import org.objectweb.asm.tree.VarInsnNode;
+
+import cpw.mods.fml.common.FMLLog;
+
+/**
+ *A simple Class Transformer for language hooks. 
+ *@author Ghostrec35 
+ **/
+
+public class WAWLAClassTransformer implements IClassTransformer 
+{
+    @Override
+    public byte[] transform(String name, String transformedName, byte[] classBytes)
+    {
+        if(name.equals("net.minecraft.util.StringTranslate"))
+        {
+            return injectStrTransHook(classBytes);
+        }
+        return classBytes;
+    }
+
+    private byte[] injectStrTransHook(byte[] classBytes)
+    {
+        boolean isInjected = false;
+        
+        ClassReader cr = new ClassReader(classBytes);
+        ClassNode cn = new ClassNode();
+        cr.accept(cn, 0);
+        for(MethodNode node : cn.methods)
+        {
+            if(node.name.equals("tryTranslateKey") && node.desc.equals("(Ljava/lang/String;)Ljava/lang/String;"))
+            {
+                for(int i = 0; i < node.instructions.size(); i++)
+                {
+                    if(node.instructions.get(i).getOpcode() == Opcodes.IFNONNULL && !isInjected)
+                    {
+                        AbstractInsnNode location = node.instructions.get(i - 4);
+                        InsnList list = new InsnList();
+                        LabelNode l0 = new LabelNode();
+                        list.add(l0);
+                        list.add(new VarInsnNode(Opcodes.ALOAD, 1));
+                        list.add(new VarInsnNode(Opcodes.ALOAD, 2));
+                        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/darkhax/wawla/handler/TranslationHooks", "tryTranslateKey", "(Ljava/lang/String;Ljava/lang/String;)V"));
+                        node.instructions.insert(location, list);
+                        isInjected = true;
+                        break;
+                    }
+                }
+            }
+        }
+        
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_FRAMES + ClassWriter.COMPUTE_MAXS);
+        cn.accept(writer);
+        return writer.toByteArray();
+    }
+}

--- a/src/main/java/net/darkhax/wawla/asm/WAWLALoadingPlugin.java
+++ b/src/main/java/net/darkhax/wawla/asm/WAWLALoadingPlugin.java
@@ -1,0 +1,39 @@
+package net.darkhax.wawla.asm;
+
+import java.util.Map;
+
+import cpw.mods.fml.common.FMLLog;
+import cpw.mods.fml.relauncher.IFMLLoadingPlugin;
+
+public class WAWLALoadingPlugin implements IFMLLoadingPlugin 
+{
+    @Override
+    public String[] getASMTransformerClass()
+    {
+    	FMLLog.severe("Loading CoreMod");
+        return new String[]{"net.darkhax.wawla.asm.WAWLAClassTransformer"};
+    }
+
+    @Override
+    public String getModContainerClass()
+    {
+        return null;
+    }
+
+    @Override
+    public String getSetupClass()
+    {
+        return null;
+    }
+
+    @Override
+    public void injectData(Map<String, Object> data)
+    {
+    }
+
+    @Override
+    public String getAccessTransformerClass()
+    {
+        return null;
+    }
+}

--- a/src/main/java/net/darkhax/wawla/handler/TranslationHooks.java
+++ b/src/main/java/net/darkhax/wawla/handler/TranslationHooks.java
@@ -1,0 +1,9 @@
+package net.darkhax.wawla.handler;
+
+public class TranslationHooks 
+{
+    public static void tryTranslateKey(String key, String translation)
+    {
+        System.out.println("Hook Working: Key: " + key + ", Translation: " + translation);
+    }
+}


### PR DESCRIPTION
Adds a hook into the StringTranslate tryTranslateKey(java.lang.String) method for retrieving untranslated keys.
