### PR TITLE
Fix rare crash on enchant tooltips

### DIFF
--- a/src/main/java/net/darkhax/wawla/modules/ModuleEnchantmentBooks.java
+++ b/src/main/java/net/darkhax/wawla/modules/ModuleEnchantmentBooks.java
@@ -32,8 +32,9 @@ public class ModuleEnchantmentBooks extends Module {
 
                 if (Minecraft.getMinecraft().gameSettings.isKeyDown(Minecraft.getMinecraft().gameSettings.keyBindSneak)) {
 
-                    Enchantment ench = Utilities.getEnchantmentsFromStack(stack, true)[0];
-
+                    Enchantment[] enchArr = Utilities.getEnchantmentsFromStack(stack, true);
+                    Enchantment   ench    = enchArr.length > 0 ? enchArr[0] : null;
+                    
                     if (ench != null && !blacklist.contains(ench))
                         Utilities.wrapStringToList(StatCollector.translateToLocal("description." + ench.getName()), 45, false, toolTip);
                 }


### PR DESCRIPTION
Caused by some other weird mods' enchants doing dumb stuff

Also written in github...lol
